### PR TITLE
feat: add --exclude-labels and --sort flags

### DIFF
--- a/internal/cli/issues.go
+++ b/internal/cli/issues.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 
 	"github.com/joa23/linear-cli/internal/format"
+	paginationutil "github.com/joa23/linear-cli/internal/linear/pagination"
 	"github.com/joa23/linear-cli/internal/service"
 	"github.com/spf13/cobra"
 )
@@ -44,6 +45,8 @@ func newIssuesListCmd() *cobra.Command {
 		cycle      string
 		project    string
 		labels     string
+		excludeLabels string
+		sortBy     string
 		limit      int
 		formatStr  string
 		outputType string
@@ -159,6 +162,12 @@ TIP: Use --format full for detailed output, --format minimal for concise output.
 			if labels != "" {
 				filters.LabelIDs = parseCommaSeparated(labels)
 			}
+			if excludeLabels != "" {
+				filters.ExcludeLabelIDs = parseCommaSeparated(excludeLabels)
+			}
+			if sortBy != "" {
+				filters.OrderBy = paginationutil.MapSortField(sortBy)
+			}
 
 			result, err := deps.Issues.SearchWithOutput(filters, verbosity, output)
 			if err != nil {
@@ -177,6 +186,8 @@ TIP: Use --format full for detailed output, --format minimal for concise output.
 	cmd.Flags().StringVarP(&cycle, "cycle", "c", "", "Filter by cycle (number, 'current', or 'next')")
 	cmd.Flags().StringVarP(&project, "project", "P", "", "Filter by project name or ID")
 	cmd.Flags().StringVarP(&labels, "labels", "l", "", "Filter by labels (comma-separated)")
+	cmd.Flags().StringVarP(&excludeLabels, "exclude-labels", "L", "", "Exclude issues with these labels (comma-separated)")
+	cmd.Flags().StringVarP(&sortBy, "sort", "s", "", "Sort by: created, updated")
 	cmd.Flags().IntVarP(&limit, "limit", "n", 10, "Number of items (max 250)")
 	cmd.Flags().StringVarP(&formatStr, "format", "f", "compact", "Verbosity level: minimal|compact|full")
 	cmd.Flags().StringVarP(&outputType, "output", "o", "text", "Output format: text|json")

--- a/internal/cli/search.go
+++ b/internal/cli/search.go
@@ -18,6 +18,7 @@ type IssueSearchOptions struct {
 	Assignee    string
 	Cycle       string
 	Labels      string
+	ExcludeLabels string
 	BlockedBy   string
 	Blocks      string
 	HasBlockers bool
@@ -41,6 +42,7 @@ func newSearchCmd() *cobra.Command {
 		assignee string
 		cycle    string
 		labels   string
+		excludeLabels string
 
 		// Dependency filters (NEW)
 		blockedBy     string
@@ -155,6 +157,7 @@ TIP: Use --format full for detailed output with descriptions.`,
 					Assignee:    assignee,
 					Cycle:       cycle,
 					Labels:      labels,
+					ExcludeLabels: excludeLabels,
 					BlockedBy:   blockedBy,
 					Blocks:      blocks,
 					HasBlockers: hasBlockers,
@@ -189,6 +192,7 @@ TIP: Use --format full for detailed output with descriptions.`,
 	cmd.Flags().StringVarP(&assignee, "assignee", "a", "", "Filter by assignee")
 	cmd.Flags().StringVarP(&cycle, "cycle", "c", "", "Filter by cycle")
 	cmd.Flags().StringVarP(&labels, "labels", "l", "", "Filter by labels (comma-separated)")
+	cmd.Flags().StringVarP(&excludeLabels, "exclude-labels", "L", "", "Exclude issues with these labels (comma-separated)")
 
 	// Dependency filters (NEW)
 	cmd.Flags().StringVar(&blockedBy, "blocked-by", "", "Issues blocked by this issue ID")
@@ -246,6 +250,9 @@ func searchIssues(deps *Dependencies, opts IssueSearchOptions) error {
 	}
 	if opts.Labels != "" {
 		filters.LabelIDs = parseCommaSeparated(opts.Labels)
+	}
+	if opts.ExcludeLabels != "" {
+		filters.ExcludeLabelIDs = parseCommaSeparated(opts.ExcludeLabels)
 	}
 
 	// For dependency filters, use the Search service

--- a/internal/linear/core/types.go
+++ b/internal/linear/core/types.go
@@ -638,6 +638,7 @@ type IssueFilter struct {
 	StateIDs   []string `json:"stateIds,omitempty"`   // Filter by workflow state IDs
 	AssigneeID string   `json:"assigneeId,omitempty"` // Filter by assignee user ID
 	LabelIDs   []string `json:"labelIds,omitempty"`   // Filter by label IDs
+	ExcludeLabelIDs []string `json:"excludeLabelIds,omitempty"` // Exclude issues with these label IDs
 	ProjectID  string   `json:"projectId,omitempty"`  // Filter by project ID
 	TeamID     string   `json:"teamId,omitempty"`     // Filter by team ID
 
@@ -720,6 +721,7 @@ type IssueSearchFilters struct {
 
 	// Label filters
 	LabelIDs []string `json:"labelIds,omitempty"`
+	ExcludeLabelIDs []string `json:"excludeLabelIds,omitempty"`
 
 	// Assignee filter
 	AssigneeID string `json:"assigneeId,omitempty"`
@@ -744,6 +746,9 @@ type IssueSearchFilters struct {
 	CreatedBefore string `json:"createdBefore,omitempty"`
 	UpdatedAfter  string `json:"updatedAfter,omitempty"`
 	UpdatedBefore string `json:"updatedBefore,omitempty"`
+
+	// Sorting
+	OrderBy string `json:"orderBy,omitempty"` // Sort field: "createdAt", "updatedAt"
 
 	// Pagination
 	Limit int    `json:"limit"`

--- a/internal/linear/issues/client.go
+++ b/internal/linear/issues/client.go
@@ -728,8 +728,8 @@ func (ic *Client) SearchIssuesEnhanced(filters *core.IssueSearchFilters) (*core.
 	}
 	
 	const query = `
-		query SearchIssuesEnhanced($filter: IssueFilter, $first: Int, $after: String, $includeArchived: Boolean) {
-			issues(filter: $filter, first: $first, after: $after, includeArchived: $includeArchived) {
+		query SearchIssuesEnhanced($filter: IssueFilter, $first: Int, $after: String, $includeArchived: Boolean, $orderBy: PaginationOrderBy) {
+			issues(filter: $filter, first: $first, after: $after, includeArchived: $includeArchived, orderBy: $orderBy) {
 				nodes {
 					id
 					identifier
@@ -819,13 +819,37 @@ func (ic *Client) SearchIssuesEnhanced(filters *core.IssueSearchFilters) (*core.
 		}
 	}
 	
-	// Label filters
-	if len(filters.LabelIDs) > 0 {
+	// Label filters (include and/or exclude)
+	hasIncludeLabels := len(filters.LabelIDs) > 0
+	hasExcludeLabels := len(filters.ExcludeLabelIDs) > 0
+	if hasIncludeLabels && hasExcludeLabels {
+		// Both include and exclude: use "and" since both target the "labels" key
+		filter["and"] = []interface{}{
+			map[string]interface{}{
+				"labels": map[string]interface{}{
+					"some": map[string]interface{}{
+						"id": map[string]interface{}{"in": filters.LabelIDs},
+					},
+				},
+			},
+			map[string]interface{}{
+				"labels": map[string]interface{}{
+					"every": map[string]interface{}{
+						"id": map[string]interface{}{"nin": filters.ExcludeLabelIDs},
+					},
+				},
+			},
+		}
+	} else if hasIncludeLabels {
 		filter["labels"] = map[string]interface{}{
 			"some": map[string]interface{}{
-				"id": map[string]interface{}{
-					"in": filters.LabelIDs,
-				},
+				"id": map[string]interface{}{"in": filters.LabelIDs},
+			},
+		}
+	} else if hasExcludeLabels {
+		filter["labels"] = map[string]interface{}{
+			"every": map[string]interface{}{
+				"id": map[string]interface{}{"nin": filters.ExcludeLabelIDs},
 			},
 		}
 	}
@@ -914,6 +938,11 @@ func (ic *Client) SearchIssuesEnhanced(filters *core.IssueSearchFilters) (*core.
 	// Always include the includeArchived parameter (defaults to false)
 	variables["includeArchived"] = filters.IncludeArchived
 	
+	// Add orderBy if specified
+	if filters.OrderBy != "" {
+		variables["orderBy"] = filters.OrderBy
+	}
+
 	var response struct {
 		Issues struct {
 			Nodes    []core.Issue `json:"nodes"`
@@ -1826,6 +1855,25 @@ func buildFilterObject(filter *core.IssueFilter) map[string]interface{} {
 			"id": map[string]interface{}{
 				"in": filter.LabelIDs,
 			},
+		}
+	}
+
+	// Exclude label filter
+	if len(filter.ExcludeLabelIDs) > 0 {
+		excludeFilter := map[string]interface{}{
+			"every": map[string]interface{}{
+				"id": map[string]interface{}{"nin": filter.ExcludeLabelIDs},
+			},
+		}
+		if existing, ok := filterObj["labels"]; ok {
+			// Combine with existing include filter using "and"
+			delete(filterObj, "labels")
+			filterObj["and"] = []interface{}{
+				map[string]interface{}{"labels": existing},
+				map[string]interface{}{"labels": excludeFilter},
+			}
+		} else {
+			filterObj["labels"] = excludeFilter
 		}
 	}
 

--- a/internal/service/issue.go
+++ b/internal/service/issue.go
@@ -32,8 +32,10 @@ type SearchFilters struct {
 	ProjectID  string
 	StateIDs   []string
 	LabelIDs   []string
+	ExcludeLabelIDs []string
 	Priority   *int
 	SearchTerm string
+	OrderBy    string
 	Limit      int
 	After      string
 	Format     format.Format
@@ -134,9 +136,22 @@ func (s *IssueService) Search(filters *SearchFilters) (string, error) {
 		linearFilters.LabelIDs = resolvedLabels
 	}
 
+	// Resolve exclude-label names to IDs (requires team)
+	if len(filters.ExcludeLabelIDs) > 0 {
+		if linearFilters.TeamID == "" {
+			return "", fmt.Errorf("--team is required when filtering by labels")
+		}
+		resolvedLabels, err := s.resolveLabelIDs(filters.ExcludeLabelIDs, linearFilters.TeamID)
+		if err != nil {
+			return "", err
+		}
+		linearFilters.ExcludeLabelIDs = resolvedLabels
+	}
+
 	// Copy remaining filters
 	linearFilters.Priority = filters.Priority
 	linearFilters.SearchTerm = filters.SearchTerm
+	linearFilters.OrderBy = filters.OrderBy
 
 	// Execute search
 	result, err := s.client.SearchIssues(linearFilters)
@@ -226,16 +241,36 @@ func (s *IssueService) SearchWithOutput(filters *SearchFilters, verbosity format
 
 	// Resolve project identifier if provided
 	if filters.ProjectID != "" {
-		projectID, err := s.client.ResolveProjectIdentifier(filters.ProjectID)
+		teamID := linearFilters.TeamID
+		if teamID == "" {
+			// Try to resolve team for project lookup
+			if resolvedTeam, err := s.client.ResolveTeamIdentifier(filters.TeamID); err == nil {
+				teamID = resolvedTeam
+			}
+		}
+		projectID, err := s.client.ResolveProjectIdentifier(filters.ProjectID, teamID)
 		if err != nil {
 			return "", fmt.Errorf("failed to resolve project '%s': %w", filters.ProjectID, err)
 		}
 		linearFilters.ProjectID = projectID
 	}
 
+	// Resolve exclude-label names to IDs (requires team)
+	if len(filters.ExcludeLabelIDs) > 0 {
+		if linearFilters.TeamID == "" {
+			return "", fmt.Errorf("--team is required when filtering by labels")
+		}
+		resolvedLabels, err := s.resolveLabelIDs(filters.ExcludeLabelIDs, linearFilters.TeamID)
+		if err != nil {
+			return "", err
+		}
+		linearFilters.ExcludeLabelIDs = resolvedLabels
+	}
+
 	// Copy remaining filters
 	linearFilters.Priority = filters.Priority
 	linearFilters.SearchTerm = filters.SearchTerm
+	linearFilters.OrderBy = filters.OrderBy
 
 	// Execute search
 	result, err := s.client.SearchIssues(linearFilters)


### PR DESCRIPTION
## Summary

Fixes #21

- Add `--exclude-labels` / `-L` to `issues list` and `search` to filter out issues with specific labels (server-side via `every.id.nin`)
- Wire existing sorting infrastructure to `--sort` / `-s` (`created`, `updated`) on `issues list` via `PaginationOrderBy`
- When `--labels` and `--exclude-labels` are combined, uses `and` combinator in the GraphQL filter

## Test plan
- [ ] `linear issues list --exclude-labels "wontfix" --team <KEY>` excludes matching issues
- [ ] `linear issues list --labels bug --exclude-labels wontfix` combines include + exclude
- [ ] `linear issues list --sort created` returns newest-created first
- [ ] `linear issues list --sort updated` returns most-recently-updated first
- [ ] `linear search --exclude-labels "duplicate"` works in search
- [ ] `make test` passes

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)