### PR TITLE
fix: make issue creation atomic to prevent orphaned issues

### DIFF
--- a/internal/linear/client.go
+++ b/internal/linear/client.go
@@ -236,18 +236,8 @@ func (c *Client) TeamClient() *teams.Client {
 // These methods maintain the existing API surface while delegating to sub-clients
 
 // Issue operations
-func (c *Client) CreateIssue(title, description, teamKeyOrName string) (*core.Issue, error) {
-	// Resolve team name/key to UUID if needed
-	teamID := teamKeyOrName
-	if !identifiers.IsUUID(teamKeyOrName) {
-		resolvedID, err := c.resolver.ResolveTeam(teamKeyOrName)
-		if err != nil {
-			return nil, err
-		}
-		teamID = resolvedID
-	}
-
-	return c.Issues.CreateIssue(title, description, teamID)
+func (c *Client) CreateIssue(input *core.IssueCreateInput) (*core.Issue, error) {
+	return c.Issues.CreateIssue(input)
 }
 
 // GetIssue retrieves an issue with the best context automatically determined

--- a/internal/linear/core/types.go
+++ b/internal/linear/core/types.go
@@ -610,6 +610,24 @@ type NotificationComment struct {
 	Body string `json:"body"`
 }
 
+// IssueCreateInput represents the input for creating an issue atomically.
+// All optional fields are resolved to UUIDs by the service layer before populating this struct.
+type IssueCreateInput struct {
+	Title       string
+	Description string
+	TeamID      string
+	AssigneeID  string
+	CycleID     string
+	DelegateID  string
+	DueDate     string
+	Estimate    *float64
+	LabelIDs    []string
+	ParentID    string
+	Priority    *int
+	ProjectID   string
+	StateID     string
+}
+
 // UpdateIssueInput represents the input for updating an issue
 // All fields are optional to support partial updates
 type UpdateIssueInput struct {

--- a/internal/linear/core/types.go
+++ b/internal/linear/core/types.go
@@ -618,7 +618,6 @@ type IssueCreateInput struct {
 	TeamID      string
 	AssigneeID  string
 	CycleID     string
-	DelegateID  string
 	DueDate     string
 	Estimate    *float64
 	LabelIDs    []string

--- a/internal/service/client_interfaces.go
+++ b/internal/service/client_interfaces.go
@@ -16,7 +16,7 @@ import (
 // enabling mock implementations for unit testing.
 type IssueClientOperations interface {
 	// Smart resolver-aware methods (kept in Phase 2)
-	CreateIssue(title, description, teamKeyOrName string) (*core.Issue, error)
+	CreateIssue(input *core.IssueCreateInput) (*core.Issue, error)
 	GetIssue(identifierOrID string) (*core.Issue, error)
 	UpdateIssue(identifierOrID string, input core.UpdateIssueInput) (*core.Issue, error)
 	UpdateIssueState(identifierOrID, stateID string) error

--- a/internal/service/issue.go
+++ b/internal/service/issue.go
@@ -399,70 +399,46 @@ func (s *IssueService) Create(input *CreateIssueInput) (string, error) {
 		return "", fmt.Errorf("failed to resolve team '%s': %w", input.TeamID, err)
 	}
 
-	// Create the issue
-	issue, err := s.client.CreateIssue(input.Title, input.Description, teamID)
-	if err != nil {
-		return "", fmt.Errorf("failed to create issue: %w", err)
+	// Build the atomic create input — resolve all identifiers before the API call
+	// so that a failure leaves no orphaned issue.
+	createInput := core.IssueCreateInput{
+		Title:       input.Title,
+		Description: input.Description,
+		TeamID:      teamID,
+		Priority:    input.Priority,
+		Estimate:    input.Estimate,
+		DueDate:     input.DueDate,
+		ParentID:    input.ParentID,
+		ProjectID:   input.ProjectID,
 	}
 
-	// Update with additional fields if provided
-	updateInput := core.UpdateIssueInput{}
-	needsUpdate := false
-
 	if input.StateID != "" {
-		// Resolve state name to ID if needed
 		stateID, err := s.resolveStateID(input.StateID, teamID)
 		if err != nil {
 			return "", fmt.Errorf("could not resolve state '%s': %w\n\nRun 'linear onboard' to see valid states for your teams", input.StateID, err)
 		}
-		updateInput.StateID = &stateID
-		needsUpdate = true
+		createInput.StateID = stateID
 	}
+
 	if input.AssigneeID != "" {
-		// Resolve user identifier
 		resolved, err := s.client.ResolveUserIdentifier(input.AssigneeID)
 		if err != nil {
 			return "", fmt.Errorf("failed to resolve user '%s': %w", input.AssigneeID, err)
 		}
-		// Use delegateId for OAuth applications, assigneeId for human users
-		if resolved.IsApplication {
-			updateInput.DelegateID = &resolved.ID
-		} else {
-			updateInput.AssigneeID = &resolved.ID
-		}
-		needsUpdate = true
+		// Linear's issueCreate only supports assigneeId (not delegateId),
+		// so we use the resolved user ID for both human users and OAuth apps.
+		createInput.AssigneeID = resolved.ID
 	}
-	if input.Priority != nil {
-		updateInput.Priority = input.Priority
-		needsUpdate = true
-	}
-	if input.Estimate != nil {
-		updateInput.Estimate = input.Estimate
-		needsUpdate = true
-	}
-	if input.DueDate != "" {
-		updateInput.DueDate = &input.DueDate
-		needsUpdate = true
-	}
-	if input.ParentID != "" {
-		updateInput.ParentID = &input.ParentID
-		needsUpdate = true
-	}
-	if input.ProjectID != "" {
-		updateInput.ProjectID = &input.ProjectID
-		needsUpdate = true
-	}
+
 	if input.CycleID != "" {
-		// Resolve cycle identifier
 		cycleID, err := s.client.ResolveCycleIdentifier(input.CycleID, teamID)
 		if err != nil {
 			return "", fmt.Errorf("failed to resolve cycle '%s': %w", input.CycleID, err)
 		}
-		updateInput.CycleID = &cycleID
-		needsUpdate = true
+		createInput.CycleID = cycleID
 	}
+
 	if len(input.LabelIDs) > 0 {
-		// Resolve label names to IDs
 		resolvedLabelIDs := make([]string, 0, len(input.LabelIDs))
 		for _, labelName := range input.LabelIDs {
 			labelID, err := s.client.ResolveLabelIdentifier(labelName, teamID)
@@ -471,18 +447,16 @@ func (s *IssueService) Create(input *CreateIssueInput) (string, error) {
 			}
 			resolvedLabelIDs = append(resolvedLabelIDs, labelID)
 		}
-		updateInput.LabelIDs = resolvedLabelIDs
-		needsUpdate = true
+		createInput.LabelIDs = resolvedLabelIDs
 	}
 
-	if needsUpdate {
-		issue, err = s.client.UpdateIssue(issue.ID, updateInput)
-		if err != nil {
-			return "", fmt.Errorf("failed to update issue after creation: %w", err)
-		}
+	// Single atomic API call — if this fails, no orphaned issue is created.
+	issue, err := s.client.CreateIssue(&createInput)
+	if err != nil {
+		return "", fmt.Errorf("failed to create issue: %w", err)
 	}
 
-	// Store dependencies in metadata if provided
+	// Store dependencies in metadata if provided (separate metadata API).
 	if len(input.DependsOn) > 0 {
 		if err := s.client.UpdateIssueMetadataKey(issue.ID, "dependencies", input.DependsOn); err != nil {
 			return "", fmt.Errorf("failed to set dependencies metadata: %w", err)

--- a/internal/service/issue_create_test.go
+++ b/internal/service/issue_create_test.go
@@ -1,0 +1,192 @@
+package service
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/joa23/linear-cli/internal/format"
+	"github.com/joa23/linear-cli/internal/linear"
+	"github.com/joa23/linear-cli/internal/linear/comments"
+	"github.com/joa23/linear-cli/internal/linear/core"
+	"github.com/joa23/linear-cli/internal/linear/issues"
+	"github.com/joa23/linear-cli/internal/linear/teams"
+	"github.com/joa23/linear-cli/internal/linear/workflows"
+)
+
+// mockIssueClientForCreate records CreateIssue and UpdateIssue calls to verify
+// that issue creation is atomic (UpdateIssue must never be called after CreateIssue).
+type mockIssueClientForCreate struct {
+	// Captured inputs
+	lastCreateInput *core.IssueCreateInput
+
+	// Call tracking
+	createCalled bool
+	updateCalled bool
+
+	// Configured return values
+	createResult *core.Issue
+	createErr    error
+}
+
+func (m *mockIssueClientForCreate) CreateIssue(input *core.IssueCreateInput) (*core.Issue, error) {
+	m.createCalled = true
+	m.lastCreateInput = input
+	return m.createResult, m.createErr
+}
+
+func (m *mockIssueClientForCreate) UpdateIssue(id string, input core.UpdateIssueInput) (*core.Issue, error) {
+	m.updateCalled = true
+	return nil, nil
+}
+
+// Resolver stubs — return predictable UUIDs.
+func (m *mockIssueClientForCreate) ResolveTeamIdentifier(key string) (string, error) {
+	return "team-uuid", nil
+}
+func (m *mockIssueClientForCreate) ResolveUserIdentifier(nameOrEmail string) (*linear.ResolvedUser, error) {
+	return &linear.ResolvedUser{ID: "user-uuid", IsApplication: false}, nil
+}
+func (m *mockIssueClientForCreate) ResolveCycleIdentifier(num, team string) (string, error) {
+	return "cycle-uuid", nil
+}
+func (m *mockIssueClientForCreate) ResolveLabelIdentifier(label, team string) (string, error) {
+	return "label-uuid-" + label, nil
+}
+
+// Unused interface methods.
+func (m *mockIssueClientForCreate) GetIssue(id string) (*core.Issue, error) { return nil, nil }
+func (m *mockIssueClientForCreate) UpdateIssueState(id, state string) error  { return nil }
+func (m *mockIssueClientForCreate) AssignIssue(id, assignee string) error    { return nil }
+func (m *mockIssueClientForCreate) ListAssignedIssues(limit int) ([]core.Issue, error) {
+	return nil, nil
+}
+func (m *mockIssueClientForCreate) SearchIssues(filters *core.IssueSearchFilters) (*core.IssueSearchResult, error) {
+	return nil, nil
+}
+func (m *mockIssueClientForCreate) UpdateIssueMetadataKey(id, key string, val interface{}) error {
+	return nil
+}
+func (m *mockIssueClientForCreate) CommentClient() *comments.Client   { return nil }
+func (m *mockIssueClientForCreate) WorkflowClient() *workflows.Client { return nil }
+func (m *mockIssueClientForCreate) IssueClient() *issues.Client       { return nil }
+func (m *mockIssueClientForCreate) TeamClient() *teams.Client         { return nil }
+
+// makeIssueServiceForCreate creates an IssueService backed by the given mock.
+func makeIssueServiceForCreate(mock *mockIssueClientForCreate) *IssueService {
+	return NewIssueService(mock, format.New())
+}
+
+func TestIssueService_Create_AtomicFields(t *testing.T) {
+	priority := 1
+	estimate := 3.0
+
+	t.Run("all optional fields go through CreateIssue, UpdateIssue never called", func(t *testing.T) {
+		fakeIssue := &core.Issue{ID: "issue-123", Identifier: "TL-1", Title: "My issue"}
+		mock := &mockIssueClientForCreate{
+			createResult: fakeIssue,
+		}
+		svc := makeIssueServiceForCreate(mock)
+
+		_, err := svc.Create(&CreateIssueInput{
+			Title:     "My issue",
+			TeamID:    "TL",
+			AssigneeID: "john@company.com",
+			LabelIDs:  []string{"Bugfix", "Feature"},
+			Priority:  &priority,
+			Estimate:  &estimate,
+			DueDate:   "2026-03-01",
+			ParentID:  "parent-uuid",
+			ProjectID: "project-uuid",
+			CycleID:   "65",
+		})
+
+		if err != nil {
+			t.Fatalf("Create() returned unexpected error: %v", err)
+		}
+		if !mock.createCalled {
+			t.Fatal("CreateIssue was not called")
+		}
+		if mock.updateCalled {
+			t.Fatal("UpdateIssue was called — issue creation is not atomic")
+		}
+
+		in := mock.lastCreateInput
+		if in == nil {
+			t.Fatal("lastCreateInput is nil")
+		}
+		if in.Title != "My issue" {
+			t.Errorf("Title = %q, want %q", in.Title, "My issue")
+		}
+		if in.TeamID != "team-uuid" {
+			t.Errorf("TeamID = %q, want %q", in.TeamID, "team-uuid")
+		}
+		if in.AssigneeID != "user-uuid" {
+			t.Errorf("AssigneeID = %q, want %q", in.AssigneeID, "user-uuid")
+		}
+		if len(in.LabelIDs) != 2 {
+			t.Errorf("len(LabelIDs) = %d, want 2", len(in.LabelIDs))
+		}
+		if in.Priority == nil || *in.Priority != priority {
+			t.Errorf("Priority = %v, want %d", in.Priority, priority)
+		}
+		if in.Estimate == nil || *in.Estimate != estimate {
+			t.Errorf("Estimate = %v, want %f", in.Estimate, estimate)
+		}
+		if in.DueDate != "2026-03-01" {
+			t.Errorf("DueDate = %q, want %q", in.DueDate, "2026-03-01")
+		}
+		if in.ParentID != "parent-uuid" {
+			t.Errorf("ParentID = %q, want %q", in.ParentID, "parent-uuid")
+		}
+		if in.ProjectID != "project-uuid" {
+			t.Errorf("ProjectID = %q, want %q", in.ProjectID, "project-uuid")
+		}
+		if in.CycleID != "cycle-uuid" {
+			t.Errorf("CycleID = %q, want %q", in.CycleID, "cycle-uuid")
+		}
+	})
+
+	t.Run("minimal creation (title + team only) never calls UpdateIssue", func(t *testing.T) {
+		fakeIssue := &core.Issue{ID: "issue-456", Identifier: "TL-2", Title: "Minimal"}
+		mock := &mockIssueClientForCreate{
+			createResult: fakeIssue,
+		}
+		svc := makeIssueServiceForCreate(mock)
+
+		_, err := svc.Create(&CreateIssueInput{
+			Title:  "Minimal",
+			TeamID: "TL",
+		})
+
+		if err != nil {
+			t.Fatalf("Create() returned unexpected error: %v", err)
+		}
+		if !mock.createCalled {
+			t.Fatal("CreateIssue was not called")
+		}
+		if mock.updateCalled {
+			t.Fatal("UpdateIssue was called for minimal creation")
+		}
+	})
+
+	t.Run("CreateIssue failure returns error without calling UpdateIssue", func(t *testing.T) {
+		mock := &mockIssueClientForCreate{
+			createErr: fmt.Errorf("simulated API error"),
+		}
+		svc := makeIssueServiceForCreate(mock)
+
+		_, err := svc.Create(&CreateIssueInput{
+			Title:    "Will fail",
+			TeamID:   "TL",
+			LabelIDs: []string{"Bugfix"},
+			Priority: &priority,
+		})
+
+		if err == nil {
+			t.Fatal("Create() should have returned an error")
+		}
+		if mock.updateCalled {
+			t.Fatal("UpdateIssue was called after CreateIssue failure — orphaned issue risk")
+		}
+	})
+}

--- a/internal/service/issue_delegate_test.go
+++ b/internal/service/issue_delegate_test.go
@@ -38,7 +38,7 @@ func (m *mockIssueClientForDelegate) UpdateIssue(issueID string, input core.Upda
 }
 
 // Unused interface methods - return nil/empty
-func (m *mockIssueClientForDelegate) CreateIssue(title, desc, team string) (*core.Issue, error) {
+func (m *mockIssueClientForDelegate) CreateIssue(input *core.IssueCreateInput) (*core.Issue, error) {
 	return nil, nil
 }
 func (m *mockIssueClientForDelegate) UpdateIssueState(id, state string) error { return nil }

--- a/internal/service/search_resolve_test.go
+++ b/internal/service/search_resolve_test.go
@@ -25,7 +25,7 @@ type mockIssueClient struct {
 	workflowClient       *workflows.Client
 }
 
-func (m *mockIssueClient) CreateIssue(title, desc, team string) (*core.Issue, error) {
+func (m *mockIssueClient) CreateIssue(input *core.IssueCreateInput) (*core.Issue, error) {
 	return nil, nil
 }
 func (m *mockIssueClient) GetIssue(id string) (*core.Issue, error) { return nil, nil }


### PR DESCRIPTION
## Problem

`linear issues create` used a two-step pattern: first call `issueCreate`
with only `title`, `description`, and `teamId`, then call `issueUpdate`
to apply all other fields (labels, state, assignee, priority, estimate,
due date, parent, project, cycle).

If the update failed (e.g. invalid label hierarchy, unknown state,
permission error), the CLI returned exit code 1 — but the issue from
step 1 was already in Linear with no rollback. Automated callers that
retry on failure produce duplicate issues.

## Fix

Replace the two-step pattern with a single atomic `issueCreate` mutation
that includes all optional fields upfront.

- Add `IssueCreateInput` struct to `internal/linear/core/types.go`
- Update `CreateIssue` throughout the stack to accept `*core.IssueCreateInput`
- In `service.Create()`, resolve all identifiers (state, assignee, project,
  cycle, labels) before the API call, then make one atomic mutation
- Remove the post-creation `UpdateIssue` block entirely
- Keep the dependency relation step (`CreateRelation`) as a post-create
  call — this uses a separate Linear API and cannot be included in
  `issueCreate`

**Note on OAuth app assignees:** Linear's `issueCreate` mutation does not
accept `delegateId`; the resolved user ID is passed as `assigneeId` for
both human users and OAuth applications.

## Tests

`internal/service/issue_create_test.go` — three cases:
1. All optional fields flow through `CreateIssue`; `UpdateIssue` is never
   called
2. Minimal creation (title + team only) never calls `UpdateIssue`
3. `CreateIssue` failure returns an error without calling `UpdateIssue`
   (no orphan created)

## Checklist

- [x] `make test` passes
- [x] Verified against live API: a failing mutation now errors from
      `issueCreate` directly with no issue created in Linear
- [x] Merged with current `main`