### PR TITLE
fix: Preserve AuthMode and fix scope corruption on OAuth token refresh

### DIFF
--- a/internal/token/refresher.go
+++ b/internal/token/refresher.go
@@ -160,6 +160,11 @@ func (r *Refresher) refreshTokenLocked(oldToken *TokenData) (string, error) {
 		newTokenData.RefreshToken = oldToken.RefreshToken
 	}
 
+	// Preserve old auth mode if not in response (OAuth server never returns it)
+	if newTokenData.AuthMode == "" {
+		newTokenData.AuthMode = oldToken.AuthMode
+	}
+
 	// Save new token to disk
 	if err := r.storage.SaveTokenData(newTokenData); err != nil {
 		return "", fmt.Errorf("failed to save refreshed token: %w", err)

--- a/internal/token/refresher_test.go
+++ b/internal/token/refresher_test.go
@@ -1,0 +1,135 @@
+package token
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// mockOAuthRefresher is a test double for OAuthRefresher.
+type mockOAuthRefresher struct {
+	returnData *TokenData
+	returnErr  error
+}
+
+func (m *mockOAuthRefresher) RefreshAccessToken(_ string) (*TokenData, error) {
+	return m.returnData, m.returnErr
+}
+
+func TestRefresher_PreservesAuthModeOnRefresh(t *testing.T) {
+	tempDir := t.TempDir()
+	storage := NewStorage(filepath.Join(tempDir, "token"))
+
+	// Seed storage with a token that has AuthMode set
+	err := storage.SaveTokenData(&TokenData{
+		AccessToken:  "old",
+		RefreshToken: "rt",
+		TokenType:    "Bearer",
+		AuthMode:     "agent",
+	})
+	if err != nil {
+		t.Fatalf("failed to seed token: %v", err)
+	}
+
+	// Mock returns new tokens but no AuthMode (OAuth server never returns it)
+	mock := &mockOAuthRefresher{
+		returnData: &TokenData{
+			AccessToken:  "new",
+			RefreshToken: "rt2",
+			TokenType:    "Bearer",
+		},
+	}
+
+	refresher := NewRefresher(storage, mock)
+	newToken, err := refresher.RefreshIfNeeded("old")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if newToken != "new" {
+		t.Errorf("expected returned token %q, got %q", "new", newToken)
+	}
+
+	// Verify AuthMode was preserved on disk
+	saved, err := storage.LoadTokenData()
+	if err != nil {
+		t.Fatalf("failed to load token: %v", err)
+	}
+	if saved.AuthMode != "agent" {
+		t.Errorf("expected AuthMode %q, got %q", "agent", saved.AuthMode)
+	}
+}
+
+func TestRefresher_DoesNotOverwriteAuthModeWhenPresent(t *testing.T) {
+	tempDir := t.TempDir()
+	storage := NewStorage(filepath.Join(tempDir, "token"))
+
+	err := storage.SaveTokenData(&TokenData{
+		AccessToken:  "old",
+		RefreshToken: "rt",
+		TokenType:    "Bearer",
+		AuthMode:     "agent",
+	})
+	if err != nil {
+		t.Fatalf("failed to seed token: %v", err)
+	}
+
+	// Mock returns a response that includes AuthMode — new value should win
+	mock := &mockOAuthRefresher{
+		returnData: &TokenData{
+			AccessToken:  "new",
+			RefreshToken: "rt2",
+			TokenType:    "Bearer",
+			AuthMode:     "user",
+		},
+	}
+
+	refresher := NewRefresher(storage, mock)
+	_, err = refresher.RefreshIfNeeded("old")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	saved, err := storage.LoadTokenData()
+	if err != nil {
+		t.Fatalf("failed to load token: %v", err)
+	}
+	if saved.AuthMode != "user" {
+		t.Errorf("expected AuthMode %q (new value wins), got %q", "user", saved.AuthMode)
+	}
+}
+
+func TestRefresher_PreservesRefreshTokenWhenAbsent(t *testing.T) {
+	tempDir := t.TempDir()
+	storage := NewStorage(filepath.Join(tempDir, "token"))
+
+	err := storage.SaveTokenData(&TokenData{
+		AccessToken:  "old",
+		RefreshToken: "rt-original",
+		TokenType:    "Bearer",
+		AuthMode:     "agent",
+	})
+	if err != nil {
+		t.Fatalf("failed to seed token: %v", err)
+	}
+
+	// Mock returns no RefreshToken
+	mock := &mockOAuthRefresher{
+		returnData: &TokenData{
+			AccessToken: "new",
+			TokenType:   "Bearer",
+		},
+	}
+
+	refresher := NewRefresher(storage, mock)
+	_, err = refresher.RefreshIfNeeded("old")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	saved, err := storage.LoadTokenData()
+	if err != nil {
+		t.Fatalf("failed to load token: %v", err)
+	}
+	if saved.RefreshToken != "rt-original" {
+		t.Errorf("expected RefreshToken %q to be preserved, got %q", "rt-original", saved.RefreshToken)
+	}
+}

--- a/internal/token/storage.go
+++ b/internal/token/storage.go
@@ -213,21 +213,19 @@ func (s *Storage) LoadTokenData() (*TokenData, error) {
 		return nil, fmt.Errorf("failed to read token file: %w", err)
 	}
 
-	content := SanitizeToken(string(data))
-
-	// Try parsing as JSON first (new format)
+	// Try parsing as JSON first — do NOT sanitize here; SaveTokenData already
+	// sanitizes individual token fields before writing, and sanitizing the whole
+	// document corrupts JSON string values containing spaces (e.g. "read write").
 	var tokenData TokenData
-	if err := json.Unmarshal([]byte(content), &tokenData); err == nil {
-		// Successfully parsed as JSON
+	if err := json.Unmarshal(data, &tokenData); err == nil {
 		return &tokenData, nil
 	}
 
-	// Fall back to legacy plain string format
-	// Treat as access token with no refresh capability
+	// Legacy plain-string token: sanitize the individual value.
+	content := SanitizeToken(string(data))
 	return &TokenData{
 		AccessToken: content,
 		TokenType:   "Bearer",
-		// No RefreshToken, no ExpiresAt - indicates legacy token
 	}, nil
 }
 

--- a/internal/token/storage_test.go
+++ b/internal/token/storage_test.go
@@ -109,7 +109,7 @@ func TestTokenStorage(t *testing.T) {
 		}
 	})
 
-	t.Run("load token data with newlines sanitizes", func(t *testing.T) {
+	t.Run("load legacy plain token with whitespace sanitizes", func(t *testing.T) {
 		malformedTokenPath := filepath.Join(tempDir, "malformed_token")
 
 		// Write token with newlines directly to file (bypassing SaveToken validation)
@@ -129,6 +129,30 @@ func TestTokenStorage(t *testing.T) {
 		expected := "lin_api_token123"
 		if tokenData.AccessToken != expected {
 			t.Errorf("Expected sanitized token %q, got %q", expected, tokenData.AccessToken)
+		}
+	})
+
+	t.Run("load token data JSON with spaces in scope", func(t *testing.T) {
+		jsonTokenPath := filepath.Join(tempDir, "json_scope_token")
+
+		// Write valid JSON directly — scope contains a space
+		jsonContent := `{"access_token":"tok","token_type":"Bearer","scope":"read write"}`
+		err := os.WriteFile(jsonTokenPath, []byte(jsonContent), 0600)
+		if err != nil {
+			t.Fatalf("failed to write JSON token: %v", err)
+		}
+
+		jsonStorage := NewStorage(jsonTokenPath)
+		tokenData, err := jsonStorage.LoadTokenData()
+		if err != nil {
+			t.Fatalf("failed to load token data: %v", err)
+		}
+
+		if tokenData.AccessToken != "tok" {
+			t.Errorf("expected access token %q, got %q", "tok", tokenData.AccessToken)
+		}
+		if tokenData.Scope != "read write" {
+			t.Errorf("expected scope %q (spaces preserved), got %q", "read write", tokenData.Scope)
 		}
 	})
 


### PR DESCRIPTION
## Summary

This PR addresses two remaining gaps in the OAuth token refresh flow after PR #8.

**Bug 1 — AuthMode lost after first token refresh**

`refreshTokenLocked()` already preserves `RefreshToken` from the existing token
when the OAuth server's response omits it. However, the same preservation was missing
for `AuthMode`. Since the OAuth protocol never includes `auth_mode` in a refresh
response, the field is silently dropped on the first refresh. The saved token file
then has an empty `auth_mode`, which breaks `--assignee me` resolution for users
who authenticated in agent mode.

Fix: apply the same "preserve if absent" guard to `AuthMode` in `refresher.go`,
mirroring the existing `RefreshToken` logic.

**Bug 2 — `SanitizeToken` corrupts JSON string values containing spaces**

`LoadTokenData()` called `SanitizeToken()` on the entire raw file content before
parsing it as JSON. `SanitizeToken` strips all whitespace characters, which corrupts
any JSON string value that contains a space — for example a scope field of
`"read write"` becomes `"readwrite"`. The JSON structure remained parseable, so the
corruption was silent.

`SaveTokenData` already sanitizes the individual `AccessToken` and `RefreshToken`
fields before writing, so sanitizing the whole document on load is redundant for the
JSON path and actively harmful. The fix moves `SanitizeToken` to the legacy
plain-string fallback path only, where it is still needed.

## Test plan

- [ ] `TestRefresher_PreservesAuthModeOnRefresh` — verifies `AuthMode` is carried over
  when the refresh response does not include it
- [ ] `TestRefresher_DoesNotOverwriteAuthModeWhenPresent` — verifies a new `AuthMode`
  in the response wins over the old one
- [ ] `TestRefresher_PreservesRefreshTokenWhenAbsent` — regression guard for the
  existing `RefreshToken` preservation logic
- [ ] `"load token data JSON with spaces in scope"` — directly reproduces the
  space-stripping bug and verifies the fix
- [ ] `make test` passes (all existing tests remain green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)