### PR TITLE
Expose Parent on core.Label for label-group consumers

### DIFF
--- a/pkg/linear/core/types.go
+++ b/pkg/linear/core/types.go
@@ -694,10 +694,18 @@ type IssueWithDetails struct {
 
 // Label represents a Linear label
 type Label struct {
-	ID          string `json:"id"`
-	Name        string `json:"name"`
-	Color       string `json:"color"`
-	Description string `json:"description"`
+	ID          string    `json:"id"`
+	Name        string    `json:"name"`
+	Color       string    `json:"color"`
+	Description string    `json:"description"`
+	Parent      *LabelRef `json:"parent,omitempty"`
+}
+
+// LabelRef is a minimal label reference, used for parent links so we don't
+// recurse the full Label graph.
+type LabelRef struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
 }
 
 // CreateLabelInput represents the input for creating a label

--- a/pkg/linear/issues/client.go
+++ b/pkg/linear/issues/client.go
@@ -205,6 +205,10 @@ func (ic *Client) GetIssue(issueID string) (*core.Issue, error) {
 						id
 						name
 						color
+						parent {
+							id
+							name
+						}
 					}
 				}
 				cycle {
@@ -358,6 +362,10 @@ func (ic *Client) getIssueWithProjectContextInternal(issueID string) (*core.Issu
 						id
 						name
 						color
+						parent {
+							id
+							name
+						}
 					}
 				}
 				cycle {
@@ -507,6 +515,10 @@ func (ic *Client) getIssueWithParentContextInternal(issueID string) (*core.Issue
 						id
 						name
 						color
+						parent {
+							id
+							name
+						}
 					}
 				}
 				cycle {
@@ -865,6 +877,10 @@ func (ic *Client) SearchIssuesEnhanced(filters *core.IssueSearchFilters) (*core.
 							id
 							name
 							color
+							parent {
+								id
+								name
+							}
 						}
 					}
 					priority
@@ -1120,6 +1136,10 @@ func (ic *Client) BatchUpdateIssues(issueIDs []string, update core.BatchIssueUpd
 							id
 							name
 							color
+							parent {
+								id
+								name
+							}
 						}
 					}
 					priority
@@ -1500,6 +1520,10 @@ func (ic *Client) GetIssueSimplified(issueID string) (*core.Issue, error) {
 						id
 						name
 						color
+						parent {
+							id
+							name
+						}
 					}
 				}
 				cycle {
@@ -1843,6 +1867,10 @@ func (ic *Client) ListAllIssues(filter *core.IssueFilter) (*core.ListAllIssuesRe
 							id
 							name
 							color
+							parent {
+								id
+								name
+							}
 						}
 					}
 					project {

--- a/pkg/linear/issues/client_test.go
+++ b/pkg/linear/issues/client_test.go
@@ -283,3 +283,74 @@ func TestGetIssueResponseStruct_ShadowedVersion(t *testing.T) {
 		t.Error("Shadowed struct should lose attachment data — this test proves the bug exists")
 	}
 }
+
+// TestLabelParent_Deserialization verifies that Parent is populated when the
+// GraphQL response includes a parent field on a label, and is nil when absent.
+func TestLabelParent_Deserialization(t *testing.T) {
+	// Simulated GraphQL response: one label with a parent, one without.
+	graphqlResponse := `{
+		"issue": {
+			"id": "issue-uuid",
+			"identifier": "TEC-200",
+			"title": "Issue with labels",
+			"description": "",
+			"state": {"id": "state-1", "name": "Todo"},
+			"createdAt": "2025-01-01T00:00:00Z",
+			"updatedAt": "2025-01-01T00:00:00Z",
+			"url": "https://linear.app/test/issue/TEC-200",
+			"labels": {
+				"nodes": [
+					{
+						"id": "label-child-1",
+						"name": "Bug",
+						"color": "#ff0000",
+						"description": "A bug",
+						"parent": {
+							"id": "label-parent-1",
+							"name": "Type"
+						}
+					},
+					{
+						"id": "label-orphan-1",
+						"name": "Urgent",
+						"color": "#ff9900",
+						"description": "Urgent issue"
+					}
+				]
+			}
+		}
+	}`
+
+	var response struct {
+		Issue core.Issue `json:"issue"`
+	}
+
+	if err := json.Unmarshal([]byte(graphqlResponse), &response); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+
+	if response.Issue.Labels == nil {
+		t.Fatal("Labels is nil")
+	}
+	if len(response.Issue.Labels.Nodes) != 2 {
+		t.Fatalf("expected 2 label nodes, got %d", len(response.Issue.Labels.Nodes))
+	}
+
+	// First label has a parent
+	first := response.Issue.Labels.Nodes[0]
+	if first.Parent == nil {
+		t.Fatal("Labels.Nodes[0].Parent is nil, want non-nil")
+	}
+	if first.Parent.ID != "label-parent-1" {
+		t.Errorf("Labels.Nodes[0].Parent.ID = %q, want %q", first.Parent.ID, "label-parent-1")
+	}
+	if first.Parent.Name != "Type" {
+		t.Errorf("Labels.Nodes[0].Parent.Name = %q, want %q", first.Parent.Name, "Type")
+	}
+
+	// Second label has no parent
+	second := response.Issue.Labels.Nodes[1]
+	if second.Parent != nil {
+		t.Errorf("Labels.Nodes[1].Parent = %+v, want nil", second.Parent)
+	}
+}

--- a/pkg/linear/teams/client.go
+++ b/pkg/linear/teams/client.go
@@ -573,6 +573,10 @@ func (tc *Client) ListLabels(teamID string) ([]core.Label, error) {
 						name
 						color
 						description
+						parent {
+							id
+							name
+						}
 					}
 				}
 			}

--- a/pkg/linear/teams/client_test.go
+++ b/pkg/linear/teams/client_test.go
@@ -1,0 +1,78 @@
+package teams
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/joa23/linear-cli/pkg/linear/core"
+)
+
+// TestListLabelsResponseStruct_ParentField verifies that the ListLabels response
+// struct correctly deserializes Parent on core.Label: non-nil when present, nil
+// when absent.
+func TestListLabelsResponseStruct_ParentField(t *testing.T) {
+	// Simulated GraphQL response for GetTeamLabels
+	graphqlResponse := `{
+		"team": {
+			"labels": {
+				"nodes": [
+					{
+						"id": "label-child-1",
+						"name": "Bug",
+						"color": "#ff0000",
+						"description": "A bug report",
+						"parent": {
+							"id": "label-parent-1",
+							"name": "Type"
+						}
+					},
+					{
+						"id": "label-orphan-1",
+						"name": "Urgent",
+						"color": "#ff9900",
+						"description": "Needs immediate attention"
+					}
+				]
+			}
+		}
+	}`
+
+	var response struct {
+		Team *struct {
+			Labels struct {
+				Nodes []core.Label `json:"nodes"`
+			} `json:"labels"`
+		} `json:"team"`
+	}
+
+	if err := json.Unmarshal([]byte(graphqlResponse), &response); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+
+	if response.Team == nil {
+		t.Fatal("Team is nil")
+	}
+
+	nodes := response.Team.Labels.Nodes
+	if len(nodes) != 2 {
+		t.Fatalf("expected 2 label nodes, got %d", len(nodes))
+	}
+
+	// First label has a parent
+	first := nodes[0]
+	if first.Parent == nil {
+		t.Fatal("nodes[0].Parent is nil, want non-nil")
+	}
+	if first.Parent.ID != "label-parent-1" {
+		t.Errorf("nodes[0].Parent.ID = %q, want %q", first.Parent.ID, "label-parent-1")
+	}
+	if first.Parent.Name != "Type" {
+		t.Errorf("nodes[0].Parent.Name = %q, want %q", first.Parent.Name, "Type")
+	}
+
+	// Second label has no parent
+	second := nodes[1]
+	if second.Parent != nil {
+		t.Errorf("nodes[1].Parent = %+v, want nil", second.Parent)
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `Parent *LabelRef` to `core.Label`
- Updates GraphQL queries in `pkg/linear/issues/client.go`, `pkg/linear/teams/client.go`, and any other site selecting labels, to fetch `parent { id name }`
- Pure addition; existing consumers unaffected

## Why
Conductor needs to read Linear's native label-group structure (parent label = group, child labels = values) to route per-ticket decisions. Without `Parent` exposed, callers can't tell which group a label belongs to.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...`
- [x] `go build ./cmd/linear`
- [x] New test asserts `Parent` is populated when label has a parent and nil when it doesn't