### PR TITLE
fix(issues): include creator field in GraphQL projections (#49)

### DIFF
--- a/pkg/linear/issues/client.go
+++ b/pkg/linear/issues/client.go
@@ -68,6 +68,11 @@ linear_create_issue("Task title", "Description", teams[0].id)`)
 						name
 						email
 					}
+					creator {
+						id
+						name
+						email
+					}
 					createdAt
 					updatedAt
 					url
@@ -188,6 +193,11 @@ func (ic *Client) GetIssue(issueID string) (*core.Issue, error) {
 					name
 				}
 				assignee {
+					id
+					name
+					email
+				}
+				creator {
 					id
 					name
 					email
@@ -349,6 +359,11 @@ func (ic *Client) getIssueWithProjectContextInternal(issueID string) (*core.Issu
 					name
 					email
 				}
+				creator {
+					id
+					name
+					email
+				}
 				delegate {
 					id
 					name
@@ -498,6 +513,11 @@ func (ic *Client) getIssueWithParentContextInternal(issueID string) (*core.Issue
 					name
 				}
 				assignee {
+					id
+					name
+					email
+				}
+				creator {
 					id
 					name
 					email
@@ -708,6 +728,11 @@ func (ic *Client) AssignIssue(issueID, assigneeID string) error {
 						name
 						email
 					}
+					creator {
+						id
+						name
+						email
+					}
 				}
 			}
 		}
@@ -770,6 +795,11 @@ func (ic *Client) ListAssignedIssues(limit int) ([]core.Issue, error) {
 						name
 					}
 					assignee {
+						id
+						name
+						email
+					}
+					creator {
 						id
 						name
 						email
@@ -868,6 +898,11 @@ func (ic *Client) SearchIssuesEnhanced(filters *core.IssueSearchFilters) (*core.
 						name
 					}
 					assignee {
+						id
+						name
+						email
+					}
+					creator {
 						id
 						name
 						email
@@ -1127,6 +1162,11 @@ func (ic *Client) BatchUpdateIssues(issueIDs []string, update core.BatchIssueUpd
 						name
 					}
 					assignee {
+						id
+						name
+						email
+					}
+					creator {
 						id
 						name
 						email
@@ -1507,6 +1547,11 @@ func (ic *Client) GetIssueSimplified(issueID string) (*core.Issue, error) {
 					name
 					email
 				}
+				creator {
+					id
+					name
+					email
+				}
 				delegate {
 					id
 					name
@@ -1648,6 +1693,11 @@ func (ic *Client) UpdateIssue(issueID string, input core.UpdateIssueInput) (*cor
 						name
 					}
 					assignee {
+						id
+						name
+						email
+					}
+					creator {
 						id
 						name
 						email


### PR DESCRIPTION
## Summary

Fixes #49 — `"creator": null` in every JSON response.

The `Creator` field was defined on both `core.Issue` and the JSON DTO, but **no GraphQL projection in `pkg/linear/issues/client.go` requested it**. Linear's API consequently never returned it, leaving `"creator": null` regardless of the ticket's actual creator.

This PR adds `creator { id name email }` next to every `assignee { id name email }` block — 11 spots across `GetIssue`, list, search, create, update, and context-aware variants. No structural changes; the DTO and `User` type already handle the field.

## Test plan

- [x] `make build` succeeds
- [x] `make test` — all packages pass
- [ ] Smoke test: `linear issues get CEN-XXXX --output json | jq .creator` returns the creator object (could not verify locally — auth token expired during session)

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)