### PR TITLE
feat(filter): expose --created-since/--created-after/--created-before flags (#50)

### DIFF
--- a/internal/cli/helpers.go
+++ b/internal/cli/helpers.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/joa23/linear-cli/pkg/linear"
 	"github.com/spf13/cobra"
@@ -140,6 +141,49 @@ func parsePriority(s string) (int, error) {
 	default:
 		return 0, fmt.Errorf("invalid priority '%s': use 0-4 or none/urgent/high/normal/low", s)
 	}
+}
+
+// parseCreatedSince converts a relative duration like "24h", "7d", "2w" into an
+// RFC3339 UTC timestamp for the gte side of a createdAt filter. Returns an empty
+// string when input is empty. Accepts Go's time.ParseDuration units (ns/us/ms/s/m/h)
+// plus the calendar-friendly extensions "d" (days) and "w" (weeks).
+func parseCreatedSince(s string) (string, error) {
+	if s == "" {
+		return "", nil
+	}
+
+	d, err := parseExtendedDuration(s)
+	if err != nil {
+		return "", fmt.Errorf("invalid --created-since %q: %w (expected e.g. 24h, 7d, 2w)", s, err)
+	}
+	if d <= 0 {
+		return "", fmt.Errorf("invalid --created-since %q: duration must be positive", s)
+	}
+	return time.Now().UTC().Add(-d).Format(time.RFC3339), nil
+}
+
+// parseExtendedDuration extends time.ParseDuration with day/week units.
+func parseExtendedDuration(s string) (time.Duration, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return 0, fmt.Errorf("empty duration")
+	}
+	// Translate trailing "d" / "w" suffix into hours so ParseDuration accepts it.
+	if n := len(s); n >= 2 {
+		last := s[n-1]
+		if last == 'd' || last == 'w' {
+			num, err := strconv.ParseFloat(s[:n-1], 64)
+			if err != nil {
+				return 0, err
+			}
+			hoursPerUnit := 24.0
+			if last == 'w' {
+				hoursPerUnit = 24.0 * 7.0
+			}
+			return time.Duration(num * hoursPerUnit * float64(time.Hour)), nil
+		}
+	}
+	return time.ParseDuration(s)
 }
 
 // Context key type for dependencies injection

--- a/internal/cli/helpers_test.go
+++ b/internal/cli/helpers_test.go
@@ -1,0 +1,67 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestParseCreatedSince(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantAgo time.Duration // how far back the resulting timestamp should be
+		wantErr string        // substring expected in error message; empty = no error
+	}{
+		{name: "empty returns empty", input: "", wantAgo: 0},
+		{name: "24h", input: "24h", wantAgo: 24 * time.Hour},
+		{name: "7d", input: "7d", wantAgo: 7 * 24 * time.Hour},
+		{name: "2w", input: "2w", wantAgo: 14 * 24 * time.Hour},
+		{name: "30m", input: "30m", wantAgo: 30 * time.Minute},
+		{name: "0.5d", input: "0.5d", wantAgo: 12 * time.Hour},
+		{name: "negative rejected", input: "-1h", wantErr: "must be positive"},
+		{name: "zero rejected", input: "0h", wantErr: "must be positive"},
+		{name: "garbage rejected", input: "foo", wantErr: "invalid --created-since"},
+		{name: "missing unit rejected", input: "24", wantErr: "invalid --created-since"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			before := time.Now().UTC()
+			got, err := parseCreatedSince(tt.input)
+			after := time.Now().UTC()
+
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil (result: %q)", tt.wantErr, got)
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("error %q does not contain %q", err.Error(), tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if tt.input == "" {
+				if got != "" {
+					t.Fatalf("expected empty result for empty input, got %q", got)
+				}
+				return
+			}
+
+			parsed, parseErr := time.Parse(time.RFC3339, got)
+			if parseErr != nil {
+				t.Fatalf("result %q is not valid RFC3339: %v", got, parseErr)
+			}
+
+			// Allow a small window for the actual time-of-call within parseCreatedSince.
+			earliest := before.Add(-tt.wantAgo).Add(-time.Second)
+			latest := after.Add(-tt.wantAgo).Add(time.Second)
+			if parsed.Before(earliest) || parsed.After(latest) {
+				t.Fatalf("parsed timestamp %v outside expected window [%v, %v]", parsed, earliest, latest)
+			}
+		})
+	}
+}

--- a/internal/cli/issues.go
+++ b/internal/cli/issues.go
@@ -47,6 +47,9 @@ func newIssuesListCmd() *cobra.Command {
 		labels     string
 		excludeLabels string
 		sortBy     string
+		createdSince  string
+		createdAfter  string
+		createdBefore string
 		limit      int
 		formatStr  string
 		outputType string
@@ -170,6 +173,19 @@ TIP: Use --format full for detailed output, --format minimal for concise output.
 			if sortBy != "" {
 				filters.OrderBy = paginationutil.MapSortField(sortBy)
 			}
+			if createdSince != "" {
+				ts, err := parseCreatedSince(createdSince)
+				if err != nil {
+					return err
+				}
+				filters.CreatedAfter = ts
+			}
+			if createdAfter != "" {
+				filters.CreatedAfter = createdAfter
+			}
+			if createdBefore != "" {
+				filters.CreatedBefore = createdBefore
+			}
 
 			result, err := deps.Issues.SearchWithOutput(filters, verbosity, output)
 			if err != nil {
@@ -190,6 +206,9 @@ TIP: Use --format full for detailed output, --format minimal for concise output.
 	cmd.Flags().StringVarP(&labels, "labels", "l", "", "Filter by labels (comma-separated)")
 	cmd.Flags().StringVarP(&excludeLabels, "exclude-labels", "L", "", "Exclude issues with these labels (comma-separated)")
 	cmd.Flags().StringVarP(&sortBy, "sort", "s", "", "Sort by: created, updated")
+	cmd.Flags().StringVar(&createdSince, "created-since", "", "Filter to issues created in the last duration (e.g. 24h, 7d, 2w)")
+	cmd.Flags().StringVar(&createdAfter, "created-after", "", "Filter to issues created at/after ISO-8601 timestamp")
+	cmd.Flags().StringVar(&createdBefore, "created-before", "", "Filter to issues created at/before ISO-8601 timestamp")
 	cmd.Flags().IntVarP(&limit, "limit", "n", 10, "Number of items (max 250)")
 	cmd.Flags().StringVarP(&formatStr, "format", "f", "compact", "Verbosity level: minimal|compact|detailed|full")
 	cmd.Flags().StringVarP(&outputType, "output", "o", "text", "Output format: text|json")

--- a/internal/cli/search.go
+++ b/internal/cli/search.go
@@ -26,9 +26,14 @@ type IssueSearchOptions struct {
 	HasDeps     bool
 	HasCircular bool
 	DepthMax    int
-	Limit       int
-	Format      string
-	Output      string
+	// Date filters. CreatedSince is a relative duration (24h, 7d, 2w);
+	// CreatedAfter/CreatedBefore are RFC3339 timestamps.
+	CreatedSince  string
+	CreatedAfter  string
+	CreatedBefore string
+	Limit         int
+	Format        string
+	Output        string
 }
 
 func newSearchCmd() *cobra.Command {
@@ -53,6 +58,11 @@ func newSearchCmd() *cobra.Command {
 		hasDeps       bool
 		hasCircular   bool
 		depthMax      int
+
+		// Date filters
+		createdSince  string
+		createdAfter  string
+		createdBefore string
 
 		// Output
 		limit      int
@@ -156,24 +166,27 @@ TIP: Use --format full for detailed output with descriptions.`,
 			switch entityType {
 			case "issues", "":
 				return searchIssues(deps, IssueSearchOptions{
-					TextQuery:   textQuery,
-					Team:        team,
-					Project:     project,
-					State:       state,
-					Priority:    priority,
-					Assignee:    assignee,
-					Cycle:       cycle,
-					Labels:      labels,
+					TextQuery:     textQuery,
+					Team:          team,
+					Project:       project,
+					State:         state,
+					Priority:      priority,
+					Assignee:      assignee,
+					Cycle:         cycle,
+					Labels:        labels,
 					ExcludeLabels: excludeLabels,
-					BlockedBy:   blockedBy,
-					Blocks:      blocks,
-					HasBlockers: hasBlockers,
-					HasDeps:     hasDeps,
-					HasCircular: hasCircular,
-					DepthMax:    depthMax,
-					Limit:       limit,
-					Format:      formatStr,
-					Output:      outputType,
+					BlockedBy:     blockedBy,
+					Blocks:        blocks,
+					HasBlockers:   hasBlockers,
+					HasDeps:       hasDeps,
+					HasCircular:   hasCircular,
+					DepthMax:      depthMax,
+					CreatedSince:  createdSince,
+					CreatedAfter:  createdAfter,
+					CreatedBefore: createdBefore,
+					Limit:         limit,
+					Format:        formatStr,
+					Output:        outputType,
 				})
 			case "cycles":
 				return searchCycles(deps, textQuery, team, limit, formatStr, outputType)
@@ -209,6 +222,11 @@ TIP: Use --format full for detailed output with descriptions.`,
 	cmd.Flags().BoolVar(&hasDeps, "has-dependencies", false, "Issues with dependencies")
 	cmd.Flags().BoolVar(&hasCircular, "has-circular-deps", false, "Issues in circular deps")
 	cmd.Flags().IntVar(&depthMax, "max-depth", 0, "Max dependency chain depth")
+
+	// Date filters
+	cmd.Flags().StringVar(&createdSince, "created-since", "", "Filter to issues created in the last duration (e.g. 24h, 7d, 2w)")
+	cmd.Flags().StringVar(&createdAfter, "created-after", "", "Filter to issues created at/after ISO-8601 timestamp")
+	cmd.Flags().StringVar(&createdBefore, "created-before", "", "Filter to issues created at/before ISO-8601 timestamp")
 
 	// Output
 	cmd.Flags().IntVarP(&limit, "limit", "n", 10, "Number of results")
@@ -262,6 +280,21 @@ func searchIssues(deps *Dependencies, opts IssueSearchOptions) error {
 	}
 	if opts.ExcludeLabels != "" {
 		filters.ExcludeLabelIDs = parseCommaSeparated(opts.ExcludeLabels)
+	}
+
+	// Date filters
+	if opts.CreatedSince != "" {
+		ts, err := parseCreatedSince(opts.CreatedSince)
+		if err != nil {
+			return err
+		}
+		filters.CreatedAfter = ts
+	}
+	if opts.CreatedAfter != "" {
+		filters.CreatedAfter = opts.CreatedAfter
+	}
+	if opts.CreatedBefore != "" {
+		filters.CreatedBefore = opts.CreatedBefore
 	}
 
 	// For dependency filters, use the Search service

--- a/internal/service/issue.go
+++ b/internal/service/issue.go
@@ -36,9 +36,12 @@ type SearchFilters struct {
 	Priority   *int
 	SearchTerm string
 	OrderBy    string
-	Limit      int
-	After      string
-	Format     format.Format
+	// Date filters (RFC3339 timestamps). Set via CLI --created-since/--created-after/--created-before.
+	CreatedAfter  string
+	CreatedBefore string
+	Limit         int
+	After         string
+	Format        format.Format
 }
 
 // Get retrieves a single issue by identifier (e.g., "CEN-123")
@@ -161,6 +164,8 @@ func (s *IssueService) Search(filters *SearchFilters) (string, error) {
 	linearFilters.Priority = filters.Priority
 	linearFilters.SearchTerm = filters.SearchTerm
 	linearFilters.OrderBy = filters.OrderBy
+	linearFilters.CreatedAfter = filters.CreatedAfter
+	linearFilters.CreatedBefore = filters.CreatedBefore
 
 	// Execute search
 	result, err := s.client.SearchIssues(linearFilters)
@@ -289,6 +294,8 @@ func (s *IssueService) SearchWithOutput(filters *SearchFilters, verbosity format
 	linearFilters.Priority = filters.Priority
 	linearFilters.SearchTerm = filters.SearchTerm
 	linearFilters.OrderBy = filters.OrderBy
+	linearFilters.CreatedAfter = filters.CreatedAfter
+	linearFilters.CreatedBefore = filters.CreatedBefore
 
 	// Execute search
 	result, err := s.client.SearchIssues(linearFilters)

--- a/pkg/linear/core/types.go
+++ b/pkg/linear/core/types.go
@@ -659,6 +659,10 @@ type IssueFilter struct {
 	ProjectID  string   `json:"projectId,omitempty"`  // Filter by project ID
 	TeamID     string   `json:"teamId,omitempty"`     // Filter by team ID
 
+	// Date filters (ISO-8601 timestamps)
+	CreatedAfter  string `json:"createdAfter,omitempty"`  // Issues created on/after this timestamp
+	CreatedBefore string `json:"createdBefore,omitempty"` // Issues created on/before this timestamp
+
 	// Sorting
 	OrderBy   string `json:"orderBy,omitempty"`   // Sort field: "createdAt", "updatedAt", "priority"
 	Direction string `json:"direction,omitempty"` // Sort direction: "asc" or "desc"

--- a/pkg/linear/issues/client.go
+++ b/pkg/linear/issues/client.go
@@ -2068,6 +2068,20 @@ func buildFilterObject(filter *core.IssueFilter) map[string]interface{} {
 		}
 	}
 
+	// Date filters (createdAt gte/lte)
+	if filter.CreatedAfter != "" {
+		if _, ok := filterObj["createdAt"]; !ok {
+			filterObj["createdAt"] = make(map[string]interface{})
+		}
+		filterObj["createdAt"].(map[string]interface{})["gte"] = filter.CreatedAfter
+	}
+	if filter.CreatedBefore != "" {
+		if _, ok := filterObj["createdAt"]; !ok {
+			filterObj["createdAt"] = make(map[string]interface{})
+		}
+		filterObj["createdAt"].(map[string]interface{})["lte"] = filter.CreatedBefore
+	}
+
 	return filterObj
 }
 


### PR DESCRIPTION
## Summary

Closes #50 — no CLI way to filter issues by creation date.

The GraphQL-level plumbing for `createdAt: { gte / lte }` already existed in `pkg/linear/issues/client.go` for the `IssueSearchFilters` path; this PR threads it through the CLI surface end-to-end.

**Changes:**
- `core.IssueFilter`: added `CreatedAfter` / `CreatedBefore`
- `pkg/linear/issues/client.go` `buildFilterObject`: wires the `createdAt: { gte, lte }` block (mirrors the existing search-path pattern)
- `service.SearchFilters`: added the two fields, copied into `core.IssueSearchFilters` in both `Search` and `SearchWithOutput`
- `linear search` + `linear issues list`: new flags `--created-since`, `--created-after`, `--created-before`
- `parseCreatedSince`: extends `time.ParseDuration` with `d` (days) and `w` (weeks) units, converts to RFC3339 UTC
- Unit tests cover 10 cases including negative/zero/garbage inputs

## Usage

```sh
linear search --created-since 24h --team CEN --output json --format full
linear issues list --created-since 7d --labels QA --team CEN
linear search --created-after 2026-05-01T00:00:00Z --created-before 2026-05-15T00:00:00Z
```

## Test plan

- [x] `make build` succeeds
- [x] `make test` — all packages pass (including new `TestParseCreatedSince`)
- [x] `linear search --help` and `linear issues list --help` both show the three flags
- [x] Invalid input rejected: `linear issues list --created-since foo` → clear error

Closes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)