### PR TITLE
fix: help, version, and completion no longer require authentication

### DIFF
--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/joa23/linear-cli/pkg/linear"
 	"github.com/joa23/linear-cli/internal/token"
+	"github.com/joa23/linear-cli/pkg/linear"
 	"github.com/spf13/cobra"
 )
 
@@ -184,9 +184,9 @@ Configuration:
 
 // Execute runs the CLI with dependency injection
 func Execute() {
-	// Check if this is an auth command (doesn't need client initialization)
-	if isAuthCommand() {
-		// Auth commands handle their own client creation
+	// Auth commands, help/version/completion, and a bare `linear` don't need
+	// client initialization
+	if isNoAuthInvocation(os.Args[1:]) {
 		rootCmd := NewRootCmd()
 		if err := rootCmd.Execute(); err != nil {
 			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
@@ -217,18 +217,32 @@ func Execute() {
 	}
 }
 
-// isAuthCommand checks if the current command is an auth-related command
-// that doesn't require client initialization
-func isAuthCommand() bool {
-	// Check if "auth" appears in the command arguments
-	// This handles: linear auth login, linear auth logout, linear auth status
-	for _, arg := range os.Args[1:] {
-		if arg == "auth" {
+// isNoAuthInvocation reports whether this invocation must not require
+// credentials: auth subcommands (they handle their own client creation),
+// help/version/completion, `--help`/`-h`/`--version` anywhere (cobra shows
+// help/version regardless of position), and a bare `linear` (prints help).
+// Without this, `linear --help` on a machine with no stored token and no
+// LINEAR_API_KEY exits 1 with "not authenticated" instead of printing usage.
+func isNoAuthInvocation(args []string) bool {
+	if len(args) == 0 {
+		return true // bare `linear` prints help
+	}
+	// Help/version flags trigger cobra's help path from ANY position
+	// (`linear issues create --help` must not require auth either).
+	for _, arg := range args {
+		switch arg {
+		case "-h", "--help", "--version":
 			return true
 		}
-		// Stop at first non-flag argument
+	}
+	// Otherwise the first non-flag argument is the subcommand.
+	for _, arg := range args {
 		if len(arg) > 0 && arg[0] != '-' {
-			break
+			switch arg {
+			case "auth", "help", "version", "completion":
+				return true
+			}
+			return false
 		}
 	}
 	return false

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -199,3 +199,31 @@ func TestInitializeClientWithTokenPath_LegacyPlainToken(t *testing.T) {
 	require.NotNil(t, client)
 	assert.Equal(t, "", client.GetAuthMode()) // Legacy tokens have no auth mode
 }
+
+func TestIsNoAuthInvocation(t *testing.T) {
+	cases := []struct {
+		name string
+		args []string
+		want bool
+	}{
+		{"bare invocation prints help", []string{}, true},
+		{"root help flag", []string{"--help"}, true},
+		{"root short help flag", []string{"-h"}, true},
+		{"version flag", []string{"--version"}, true},
+		{"help subcommand", []string{"help", "issues"}, true},
+		{"completion subcommand", []string{"completion", "zsh"}, true},
+		{"auth login", []string{"auth", "login"}, true},
+		{"auth after global flag", []string{"--workspace", "auth"}, true},
+		{"subcommand help flag", []string{"issues", "create", "--help"}, true},
+		{"real command needs auth", []string{"issues", "list"}, false},
+		{"real command with flags needs auth", []string{"issues", "list", "--limit", "5"}, false},
+		{"search needs auth", []string{"search", "help wanted"}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isNoAuthInvocation(tc.args); got != tc.want {
+				t.Errorf("isNoAuthInvocation(%v) = %v, want %v", tc.args, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

`Execute()` initializes the Linear client eagerly for every command except `auth`, so on a machine with no stored token and no `LINEAR_API_KEY`:

```
$ linear --help
Error: not authenticated. Run 'linear auth login' or set LINEAR_API_KEY
$ echo $?
1
```

Hit in practice by a CI toolchain smoke test that ran `linear --help` in an install step before secrets were in scope (centrum_backend reports pipeline).

## Fix

`isAuthCommand` generalized to `isNoAuthInvocation`: a bare `linear`, `-h`/`--help`/`--version` in any position (cobra shows help/version regardless of where the flag sits, incl. `linear issues create --help`), and the `help`/`version`/`completion` subcommands all skip client initialization — same early path auth commands already used. Real commands still fail fast with the existing auth error.

Table-driven test covers all the shapes; `go test ./internal/cli/` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)