### PR TITLE
fix(issues): create reports the identifier, not the description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `issues create --output json` — return the full created issue as JSON so scripted callers can read `.identifier` / `.url` unambiguously instead of scraping text.
+
+### Fixed
+
+- `issues create` no longer echoes the description back. It rendered the new issue at `full` verbosity, which re-printed the entire description the caller had just supplied and buried the identifier on line 1 under it. Reading the tail of that output, a *successful* create was indistinguishable from a failed one — so callers retried a write that had already landed and filed duplicate issues. It now prints the identifier on the first line and the URL, and nothing else.
+
 ## [1.9.1] - 2026-07-13
 
 ### Fixed

--- a/internal/cli/issues.go
+++ b/internal/cli/issues.go
@@ -295,6 +295,7 @@ func newIssuesCreateCmd() *cobra.Command {
 		dependsOn   string
 		blockedBy   string
 		attachFiles []string
+		outputType  string
 	)
 
 	cmd := &cobra.Command{
@@ -307,6 +308,10 @@ REQUIRED:
 - Team context (from 'linear init' or --team flag)
 
 OPTIONAL: All other flags (assignee, priority, labels, etc.)
+
+OUTPUT: On success, prints the new issue's identifier on the FIRST line, then its
+URL — and nothing else. The description is not echoed back. On failure it exits
+non-zero. Scripts should use --output json and read .identifier.
 
 TIP: Run 'linear init' first to set default team.`,
 		Example: `  # Minimal - create with just title (requires 'linear init')
@@ -430,7 +435,12 @@ TIP: Run 'linear init' first to set default team.`,
 				input.BlockedBy = parseCommaSeparated(blockedBy)
 			}
 
-			output, err := deps.Issues.Create(input)
+			outType, err := format.ParseOutputType(outputType)
+			if err != nil {
+				return fmt.Errorf("invalid output type: %w", err)
+			}
+
+			output, err := deps.Issues.Create(input, outType)
 			if err != nil {
 				return fmt.Errorf("failed to create issue: %w", err)
 			}
@@ -455,6 +465,7 @@ TIP: Run 'linear init' first to set default team.`,
 	cmd.Flags().StringVar(&dependsOn, "depends-on", "", "Comma-separated issue IDs this depends on")
 	cmd.Flags().StringVar(&blockedBy, "blocked-by", "", "Comma-separated issue IDs blocking this")
 	cmd.Flags().StringArrayVar(&attachFiles, "attach", nil, "Embed file as inline image in body (repeatable); for sidebar cards use: attachments create")
+	cmd.Flags().StringVarP(&outputType, "output", "o", "text", "Output format: text|json (json returns the full created issue)")
 
 	return cmd
 }

--- a/internal/format/issue.go
+++ b/internal/format/issue.go
@@ -27,6 +27,22 @@ func (f *Formatter) Issue(issue *core.Issue, fmt Format) string {
 	}
 }
 
+// IssueCreated formats the confirmation for a freshly created issue: the
+// identifier on the first line, then the URL.
+//
+// It deliberately does NOT echo the description back. `create` used to render
+// the new issue at Full, which re-printed the entire description the caller had
+// just supplied — telling them nothing they did not already know, while burying
+// the one thing they did not: the identifier. Read the tail of that output and a
+// successful create is indistinguishable from a failed one, so callers retried a
+// write that had already landed and filed duplicate issues.
+func (f *Formatter) IssueCreated(issue *core.Issue) string {
+	if issue == nil {
+		return ""
+	}
+	return fmtSprintf("%s: %s\nURL: %s", issue.Identifier, issue.Title, issue.URL)
+}
+
 // IssueList formats a list of issues with optional pagination
 func (f *Formatter) IssueList(issues []core.Issue, fmt Format, page *Pagination) string {
 	if len(issues) == 0 {

--- a/internal/service/interfaces.go
+++ b/internal/service/interfaces.go
@@ -13,7 +13,7 @@ type IssueServiceInterface interface {
 	SearchWithOutput(filters *SearchFilters, verbosity format.Verbosity, outputType format.OutputType) (string, error)
 	ListAssigned(limit int, outputFormat format.Format) (string, error)
 	ListAssignedWithPagination(pagination *core.PaginationInput) (string, error)
-	Create(input *CreateIssueInput) (string, error)
+	Create(input *CreateIssueInput, outputType format.OutputType) (string, error)
 	Update(identifier string, input *UpdateIssueInput) (string, error)
 	GetComments(identifier string) (string, error)
 	AddComment(identifier, body string) (string, error)

--- a/internal/service/issue.go
+++ b/internal/service/issue.go
@@ -455,7 +455,7 @@ type CreateIssueInput struct {
 }
 
 // Create creates a new issue
-func (s *IssueService) Create(input *CreateIssueInput) (string, error) {
+func (s *IssueService) Create(input *CreateIssueInput, outputType format.OutputType) (string, error) {
 	if input.Title == "" {
 		return "", fmt.Errorf("title is required")
 	}
@@ -551,7 +551,13 @@ func (s *IssueService) Create(input *CreateIssueInput) (string, error) {
 		}
 	}
 
-	return s.formatter.Issue(issue, format.Full), nil
+	// Report the created issue, never the description it was created with: an
+	// unambiguous `ABC-123: <title>` + URL in text mode, the full issue in JSON
+	// mode for scripted callers that need to read the identifier back reliably.
+	if outputType == format.OutputJSON {
+		return s.formatter.RenderIssue(issue, format.VerbosityFull, outputType), nil
+	}
+	return s.formatter.IssueCreated(issue), nil
 }
 
 // UpdateIssueInput represents input for updating an issue

--- a/internal/service/issue_create_test.go
+++ b/internal/service/issue_create_test.go
@@ -1,7 +1,9 @@
 package service
 
 import (
+	"encoding/json"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/joa23/linear-cli/internal/format"
@@ -55,8 +57,8 @@ func (m *mockIssueClientForCreate) ResolveLabelIdentifier(label, team string) (s
 
 // Unused interface methods.
 func (m *mockIssueClientForCreate) GetIssue(id string) (*core.Issue, error) { return nil, nil }
-func (m *mockIssueClientForCreate) UpdateIssueState(id, state string) error  { return nil }
-func (m *mockIssueClientForCreate) AssignIssue(id, assignee string) error    { return nil }
+func (m *mockIssueClientForCreate) UpdateIssueState(id, state string) error { return nil }
+func (m *mockIssueClientForCreate) AssignIssue(id, assignee string) error   { return nil }
 func (m *mockIssueClientForCreate) ListAssignedIssues(limit int) ([]core.Issue, error) {
 	return nil, nil
 }
@@ -94,17 +96,17 @@ func TestIssueService_Create_AtomicFields(t *testing.T) {
 		svc := makeIssueServiceForCreate(mock)
 
 		_, err := svc.Create(&CreateIssueInput{
-			Title:     "My issue",
-			TeamID:    "TL",
+			Title:      "My issue",
+			TeamID:     "TL",
 			AssigneeID: "john@company.com",
-			LabelIDs:  []string{"Bugfix", "Feature"},
-			Priority:  &priority,
-			Estimate:  &estimate,
-			DueDate:   "2026-03-01",
-			ParentID:  "parent-uuid",
-			ProjectID: "project-uuid",
-			CycleID:   "65",
-		})
+			LabelIDs:   []string{"Bugfix", "Feature"},
+			Priority:   &priority,
+			Estimate:   &estimate,
+			DueDate:    "2026-03-01",
+			ParentID:   "parent-uuid",
+			ProjectID:  "project-uuid",
+			CycleID:    "65",
+		}, format.OutputText)
 
 		if err != nil {
 			t.Fatalf("Create() returned unexpected error: %v", err)
@@ -162,7 +164,7 @@ func TestIssueService_Create_AtomicFields(t *testing.T) {
 		_, err := svc.Create(&CreateIssueInput{
 			Title:  "Minimal",
 			TeamID: "TL",
-		})
+		}, format.OutputText)
 
 		if err != nil {
 			t.Fatalf("Create() returned unexpected error: %v", err)
@@ -186,13 +188,80 @@ func TestIssueService_Create_AtomicFields(t *testing.T) {
 			TeamID:   "TL",
 			LabelIDs: []string{"Bugfix"},
 			Priority: &priority,
-		})
+		}, format.OutputText)
 
 		if err == nil {
 			t.Fatal("Create() should have returned an error")
 		}
 		if mock.updateCalled {
 			t.Fatal("UpdateIssue was called after CreateIssue failure — orphaned issue risk")
+		}
+	})
+}
+
+// Create must report the issue it created, never the description it was created
+// with. Rendering the new issue at Full echoed the whole body back and buried the
+// identifier on line 1, so a caller reading the tail of that output saw only its
+// own description and concluded the create had failed — then retried a write that
+// had already landed and filed a duplicate issue.
+func TestIssueService_Create_ReportsIdentifierNotDescription(t *testing.T) {
+	// A body long enough to bury the identifier, carrying the kind of dedupe
+	// marker an automated filer embeds so it can recognize its own issues later.
+	const body = "Filed automatically.\n\n<!-- dedupe:0123456789 -->"
+	const identifier = "ABC-123"
+	const issueURL = "https://linear.app/acme/issue/ABC-123"
+
+	newSvc := func() (*IssueService, *mockIssueClientForCreate) {
+		mock := &mockIssueClientForCreate{
+			createResult: &core.Issue{
+				ID:          "issue-uuid",
+				Identifier:  identifier,
+				Title:       "Fix the thing",
+				Description: body,
+				URL:         issueURL,
+			},
+		}
+		return makeIssueServiceForCreate(mock), mock
+	}
+
+	t.Run("text output leads with the identifier and omits the description", func(t *testing.T) {
+		svc, _ := newSvc()
+
+		out, err := svc.Create(&CreateIssueInput{Title: "t", TeamID: "ABC", Description: body}, format.OutputText)
+		if err != nil {
+			t.Fatalf("Create: %v", err)
+		}
+		firstLine, _, _ := strings.Cut(out, "\n")
+		if !strings.HasPrefix(firstLine, identifier+":") {
+			t.Errorf("first line = %q, want it to start with the identifier", firstLine)
+		}
+		if strings.Contains(out, "<!-- dedupe:0123456789 -->") || strings.Contains(out, "Filed automatically") {
+			t.Errorf("create echoed the description back:\n%s", out)
+		}
+		if !strings.Contains(out, issueURL) {
+			t.Errorf("create did not report the issue URL:\n%s", out)
+		}
+	})
+
+	t.Run("json output carries the identifier for scripted callers", func(t *testing.T) {
+		svc, _ := newSvc()
+
+		out, err := svc.Create(&CreateIssueInput{Title: "t", TeamID: "ABC", Description: body}, format.OutputJSON)
+		if err != nil {
+			t.Fatalf("Create: %v", err)
+		}
+		var got struct {
+			Identifier string `json:"identifier"`
+			URL        string `json:"url"`
+		}
+		if err := json.Unmarshal([]byte(out), &got); err != nil {
+			t.Fatalf("create --output json is not valid JSON: %v\n%s", err, out)
+		}
+		if got.Identifier != identifier {
+			t.Errorf("identifier = %q, want %q", got.Identifier, identifier)
+		}
+		if got.URL != issueURL {
+			t.Errorf("url = %q, want the issue URL", got.URL)
 		}
 	})
 }

--- a/internal/service/issue_relation_test.go
+++ b/internal/service/issue_relation_test.go
@@ -221,7 +221,7 @@ func TestIssueService_Create_DependsOn_CreatesRelation(t *testing.T) {
 		Title:     "New issue",
 		TeamID:    "TEST",
 		DependsOn: []string{"TEST-100"},
-	})
+	}, format.OutputText)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}


### PR DESCRIPTION
## The bug

`issues create` renders the newly created issue at `full` verbosity. That re-prints the **entire description the caller just supplied** and leaves the one thing they *didn't* know — the identifier — on line 1, buried under it.

Read the tail of that output and a **successful create is indistinguishable from a failed one**. That is what makes retrying feel safe: the caller concludes *"it echoed my description back and created nothing"*, retries a write that had already landed, and ends up with two issues for one finding.

This is not hypothetical — it has produced real duplicate issues in an automated filing pipeline: one issue created by a call that "failed", and a second filed a minute later by the retry.

An **ambiguous success is the bug**. Nobody needs the description echoed back at them; they just wrote it.

## The fix

`create` now prints the identifier on the first line and the URL, and nothing else:

```
ABC-123: Fix the thing
URL: https://linear.app/acme/issue/ABC-123
```

and gains `--output json`, so scripted callers can read `.identifier` / `.url` instead of scraping text — the same `-o` convention `issues get` and `issues list` already have (`create` was the only one without it).

## Compatibility

The first output line is `ABC-123: <title>` **before and after**, so existing scripts that parse the leading identifier keep working. Only the trailing wall of description goes away.

## Tests

- `TestIssueService_Create_ReportsIdentifierNotDescription` — pins both halves: text output leads with the identifier, carries the URL, and does **not** contain the description; JSON output round-trips `.identifier` / `.url`. Verified to **fail** against the old `format.Full` behavior ("create echoed the description back") and pass with the fix.
- Full suite green (`go test ./...`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)